### PR TITLE
Fix maze scene build order

### DIFF
--- a/genesis_lr/envs/minipupper_maze_env.py
+++ b/genesis_lr/envs/minipupper_maze_env.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import gym
 from gym import spaces
 import numpy as np
+import torch
 import genesis as gs
 
 class MiniPupperMazeEnv(gym.Env):
@@ -43,7 +44,6 @@ class MiniPupperMazeEnv(gym.Env):
             fov=90,
             GUI=False,
         )
-        self._update_camera()
 
         # build a simple maze with two walls
         h = 0.2
@@ -51,6 +51,10 @@ class MiniPupperMazeEnv(gym.Env):
         l = 4.0
         self.scene.add_entity(gs.morphs.Box(size=(l, w, h), pos=(1.0, 0.5, h/2), fixed=True))
         self.scene.add_entity(gs.morphs.Box(size=(l, w, h), pos=(1.0, -0.5, h/2), fixed=True))
+
+        self.scene.build(n_envs=1)
+        self._update_camera()
+
         self.goal_pos = np.array([2.0, 0.0])
 
         self.action_space = spaces.Discrete(3)
@@ -60,6 +64,10 @@ class MiniPupperMazeEnv(gym.Env):
     def _update_camera(self):
         pos = self.robot.get_pos()
         quat = self.robot.get_quat()
+        if isinstance(pos, torch.Tensor):
+            pos = pos.cpu().numpy()
+        if isinstance(quat, torch.Tensor):
+            quat = quat.cpu().numpy()
         offset = gs.transform_by_quat(np.array([0.2, 0.0, 0.15]), quat)
         look = gs.transform_by_quat(np.array([1.0, 0.0, 0.15]), quat)
         self.camera.set_pose(pos=pos + offset, lookat=pos + look)


### PR DESCRIPTION
## Summary
- add `torch` import
- convert pose values to numpy if returned as tensors
- build the maze scene before updating the camera

## Testing
- `python -m py_compile genesis_lr/envs/minipupper_maze_env.py`
- `python3 train.py --env minipupper_maze_env --timesteps 50000` *(fails: AttributeError: module 'genesis' has no attribute 'init')*


------
https://chatgpt.com/codex/tasks/task_e_68500f1d92448333879e4581a35ea15b