### PR TITLE
Fix MiniPupper maze env velocity API

### DIFF
--- a/genesis_lr/envs/minipupper_maze_env.py
+++ b/genesis_lr/envs/minipupper_maze_env.py
@@ -113,7 +113,8 @@ class MiniPupperMazeEnv(gym.Env):
         # similar to ``set_pos``, batched tensors are required
         vel = torch.tensor([lin], dtype=torch.float32)
         ang = torch.tensor([[0.0, 0.0, yaw]], dtype=torch.float32)
-        self.robot.set_base_velocity(linear=vel, angular=ang)
+        dofs_vel = torch.concat([vel, ang], dim=1)
+        self.robot.set_dofs_velocity(velocity=dofs_vel, dofs_idx_local=[0, 1, 2, 3, 4, 5])
 
         self.scene.step()
         self._update_camera()


### PR DESCRIPTION
## Summary
- fix base velocity control for MiniPupper maze environment

## Testing
- `python3 train.py --env minipupper_maze_env --timesteps 1` *(fails: No module named 'stable_baselines3')*
- `pip install stable-baselines3` *(fails to finish due to interruption)*

------
https://chatgpt.com/codex/tasks/task_e_6850170a4448833390c4cf50756e95bf